### PR TITLE
udoo-minimal-init: fix UEFI booting

### DIFF
--- a/recipes-core/initrdscripts/udoo-minimal-init/flash.sh
+++ b/recipes-core/initrdscripts/udoo-minimal-init/flash.sh
@@ -86,7 +86,10 @@ mount -v "${grub_data}" "${data_dir}" || \
 	exec sh
 }
 
+mkdir -p "${efi_dir}/EFI/BOOT"
 mkdir -p "${data_dir}/boot/grub"
+
+cp -av "${efi_dir}/EFI/GRUB/grubx64.efi" "${efi_dir}/EFI/BOOT/BOOTX64.EFI"
 cp -av "${liveusb_mnt}/image-boot-files/grub.cfg" "${data_dir}/boot/grub/grub.cfg"
 
 umount "${efi_dir}"


### PR DESCRIPTION
Default UEFI tries to boot /EFI/BOOT/BOOTX64.EFI
but grub installs /EFI/GRUB/grubx64.efi.