### PR TITLE
distro[udoo]: remove var TCLIBCAPPEND

### DIFF
--- a/conf/distro/udoo.conf
+++ b/conf/distro/udoo.conf
@@ -36,8 +36,6 @@ PREFERRED_PROVIDER_udev-utils ?= "systemd"
 SDK_NAME = "${DISTRO}-${TCLIBC}-${SDKMACHINE}-${IMAGE_BASENAME}-${TUNE_PKGARCH}-${MACHINE}"
 SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
 
-TCLIBCAPPEND = ""
-
 PREMIRRORS ??= "\
 bzr://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
 cvs://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \


### PR DESCRIPTION
This variable is no longer in use by OE-core