### PR TITLE
emmc.wks: use GUID for partition type

### DIFF
--- a/scripts/lib/wic/canned-wks/emmc.wks
+++ b/scripts/lib/wic/canned-wks/emmc.wks
@@ -1,5 +1,6 @@
-part bios_boot  --label bios_boot  --fstype none --fixed-size 1M  --part-type EF02
-part efi_system --label efi_system --fstype vfat --fixed-size 48M --part-type EF00
-part grub_data  --label grub_data  --fstype ext4 --fixed-size 78M --part-type 8300
-part roots      --label rootfs     --fstype ext4 --source rootfs
+# See https://wiki.archlinux.org/title/GPT_fdisk#Partition_type
+part bios_boot  --label bios_boot  --fstype none --fixed-size 1M  --part-type 21686148-6449-6E6F-744E-656564454649
+part efi_system --label efi_system --fstype vfat --fixed-size 48M --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+part grub_data  --label grub_data  --fstype ext4 --fixed-size 78M --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+part roots      --label rootfs     --fstype ext4 --source rootfs  --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4
 bootloader --ptable gpt


### PR DESCRIPTION
Newer OE-core updated
scripts/lib/wic/plugins/imager/direct.py

Which no longer uses --typecode flag as it's
believed to be deprecated.